### PR TITLE
Update kernel.js

### DIFF
--- a/src/kernel/kernel.js
+++ b/src/kernel/kernel.js
@@ -233,7 +233,7 @@
       
       info: {
         url: doc.location.href,
-        ver: navigator.appVersion.match('Chrome/([0-9\.]+)')[1],
+        ver: navigator.appVersion.match('Chrome/([0-9\.]+)') ? navigator.appVersion.match('Chrome/([0-9\.]+)')[1] : '',
         lang: navigator.language,
         id: chrome.i18n.getMessage('@@extension_id')
       },


### PR DESCRIPTION
When you use "Toggle device mode." in Chrome you get for navigator.appVersion ("5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X; en-us) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53"), so the result of navigator.appVersion.match('Chrome/([0-9\.]+)') is null and therefore you get an error "Uncaught TypeError: Cannot read property '1' of null".